### PR TITLE
Add WhisperIdentity type

### DIFF
--- a/eth_common/eth_types.nim
+++ b/eth_common/eth_types.nim
@@ -14,6 +14,8 @@ type
 
   BloomFilter* = array[256, byte]
   EthAddress* = array[20, byte]
+  
+  WhisperIdentity* = array[60, byte]
 
   DifficultyInt* = UInt256
   GasInt* = int64


### PR DESCRIPTION
Add the Whisper identity type, a 60 byte array.

Referenced here: https://github.com/ethereum/wiki/wiki/JSON-RPC#shh_post