### PR TITLE
Update transaction.V to be a range instead of UInt256

### DIFF
--- a/eth_common/eth_types.nim
+++ b/eth_common/eth_types.nim
@@ -29,7 +29,8 @@ type
     to*:            EthAddress
     value*:         UInt256
     payload*:       Blob
-    V*, R*, S*:     UInt256
+    R*, S*:         UInt256
+    V*:             range[27..28]
 
   BlockNumber* = UInt256
 


### PR DESCRIPTION
Currently `Transaction.V` is a `UInt256`, where it only needs to contain the values `27..28`.

