### PR TITLE
Workaround ICE

### DIFF
--- a/eth_common/eth_types.nim
+++ b/eth_common/eth_types.nim
@@ -31,7 +31,7 @@ type
     value*:         UInt256
     payload*:       Blob
     R*, S*:         UInt256
-    V*:             range[27..28]
+    V*:             byte
 
   BlockNumber* = UInt256
 


### PR DESCRIPTION
`range`s + `nim-rlp` = internal compiler error.

Example: https://travis-ci.org/status-im/nimbus/jobs/423903072