### PR TITLE
Change parseAddress to not need strings of full hex length

### DIFF
--- a/eth_common/utils.nim
+++ b/eth_common/utils.nim
@@ -9,7 +9,7 @@ proc toDigest*(hexString: static[string]): auto =
   toDigestAux(hexString.len div 2 * 8, hexString)
 
 proc parseAddress*(hexString: string): EthAddress =
-  hexToByteArray(hexString, result)
+  hexToPaddedByteArray[20](hexString)
 
 proc `$`*(a: EthAddress): string =
   a.toHex()


### PR DESCRIPTION
Allows `parseAddress` to handle shorter strings that aren't full length (20 byte/40 character) hex values.