### PR TITLE
modify receipt and log datatype

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,86 @@
+version: '{build}'
+
+cache:
+- x86_64-4.9.2-release-win32-seh-rt_v4-rev4.7z
+- i686-4.9.2-release-win32-dwarf-rt_v4-rev4.7z
+- Nim
+
+matrix:
+  # We always want 32 and 64-bit compilation
+  fast_finish: false
+
+platform:
+  - x86
+  - x64
+
+install:
+  - setlocal EnableExtensions EnableDelayedExpansion
+
+  - IF "%PLATFORM%" == "x86" (
+      SET "MINGW_ARCHIVE=i686-4.9.2-release-win32-dwarf-rt_v4-rev4.7z" &
+      SET "MINGW_URL=https://sourceforge.net/projects/mingw-w64/files/Toolchains%%20targetting%%20Win32/Personal%%20Builds/mingw-builds/4.9.2/threads-win32/dwarf/i686-4.9.2-release-win32-dwarf-rt_v4-rev4.7z" &
+      SET "MINGW_DIR=mingw32"
+    ) ELSE (
+      IF "%PLATFORM%" == "x64" (
+        SET "MINGW_ARCHIVE=x86_64-4.9.2-release-win32-seh-rt_v4-rev4.7z" &
+        SET "MINGW_URL=https://sourceforge.net/projects/mingw-w64/files/Toolchains%%20targetting%%20Win64/Personal%%20Builds/mingw-builds/4.9.2/threads-win32/seh/x86_64-4.9.2-release-win32-seh-rt_v4-rev4.7z" &
+        SET "MINGW_DIR=mingw64"
+      ) else (
+        echo "Unknown platform"
+      )
+    )
+
+  - SET PATH=%CD%\%MINGW_DIR%\bin;%CD%\Nim\bin;%PATH%
+
+  # Unpack mingw
+  - IF NOT EXIST "%MINGW_ARCHIVE%" appveyor DownloadFile "%MINGW_URL%" -FileName "%MINGW_ARCHIVE%"
+  - 7z x -y "%MINGW_ARCHIVE%" > nul
+
+  # build nim from our own branch - this to avoid the day-to-day churn and
+  # regressions of the fast-paced Nim development while maintaining the
+  # flexibility to apply patches
+  - SET "NEED_REBUILD="
+
+  - IF NOT EXIST "Nim\\.git\\" (
+      git clone https://github.com/status-im/Nim.git
+    ) ELSE (
+      ( cd Nim ) &
+      ( git pull ) &
+      ( cd .. )
+    )
+
+  # Rebuild Nim if HEAD has moved or if we don't yet have a cached version
+  - IF NOT EXIST "Nim\\ver.txt" (
+      SET NEED_REBUILD=1
+    ) ELSE (
+      ( CD Nim ) &
+      ( git rev-parse HEAD > ..\\cur_ver.txt ) &
+      ( fc ver.txt ..\\cur_ver.txt || SET NEED_REBUILD=1 ) &
+      ( cd .. )
+    )
+
+  - IF NOT EXIST "Nim\\bin\\nim.exe" SET NEED_REBUILD=1
+  - IF NOT EXIST "Nim\\bin\\nimble.exe" SET NEED_REBUILD=1
+
+  # after building nim, wipe csources to save on cache space
+  - IF DEFINED NEED_REBUILD (
+      cd Nim &
+      ( IF EXIST "csources" rmdir /s /q csources ) &
+      git clone --depth 1 https://github.com/nim-lang/csources &
+      cd csources &
+      ( IF "%PLATFORM%" == "x64" ( build64.bat ) else ( build.bat ) ) &
+      cd .. &
+      bin\nim c koch &
+      koch boot -d:release &
+      koch nimble &
+      git rev-parse HEAD > ver.txt &
+      rmdir /s /q csources
+    )
+
+build_script:
+  - cd C:\projects\%APPVEYOR_PROJECT_SLUG%
+  - nimble install -y
+test_script:
+  - nimble test
+
+deploy: off

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,39 @@
+language: c # or other C/C++ variants
+
+sudo: false
+
+# https://docs.travis-ci.com/user/caching/
+#
+# Caching the whole nim folder is better than relying on ccache - this way, we
+# skip the expensive bootstrap process and linking
+cache:
+  directories:
+    - nim
+
+os:
+  - linux
+  - osx
+
+install:
+  # build nim from our own branch - this to avoid the day-to-day churn and
+  # regressions of the fast-paced Nim development while maintaining the
+  # flexibility to apply patches
+  #
+  # check version of remote branch
+  - "export NIMVER=$(git ls-remote https://github.com/status-im/nim.git HEAD | cut -f 1)"
+
+  # after building nim, wipe csources to save on cache space
+  - "{ [ -f nim/$NIMVER/bin/nim ] && [ -f nim/$NIMVER/bin/nimble ] ; } ||
+      { rm -rf nim ;
+        mkdir -p nim ;
+        git clone --depth=1 https://github.com/status-im/nim.git nim/$NIMVER ;
+        cd nim/$NIMVER ;
+        sh build_all.sh ;
+        rm -rf csources ;
+        cd ../.. ;
+      }"
+  - "export PATH=$PWD/nim/$NIMVER/bin:$PATH"
+
+script:
+  - nimble install -y
+  - nimble test

--- a/eth_common.nimble
+++ b/eth_common.nimble
@@ -12,3 +12,7 @@ requires "nim > 0.18.0",
          "ranges",
          "stint",
          "byteutils"
+
+task test, "run tests":
+  cd "tests"
+  exec "nim c -r test"

--- a/eth_common/eth_types.nim
+++ b/eth_common/eth_types.nim
@@ -18,13 +18,16 @@ type
 
   BloomFilter* = array[256, byte]
   EthAddress* = array[20, byte]
-  
+
   WhisperIdentity* = array[60, byte]
 
   DifficultyInt* = UInt256
   GasInt* = int64
   ## Type alias used for gas computation
   # For reference - https://github.com/status-im/nimbus/issues/35#issuecomment-391726518
+
+  Topic* = array[32, byte]
+  # topic can be Hash256 or zero padded bytes array
 
   Account* = object
     nonce*:             AccountNonce
@@ -79,12 +82,12 @@ type
 
   Log* = object
     address*:       EthAddress
-    topics*:        seq[int32]
+    topics*:        seq[Topic]
     data*:          Blob
 
   Receipt* = object
-    stateRoot*:     Blob
-    gasUsed*:       GasInt
+    stateRootOrStatus*: Blob
+    cumulativeGasUsed*: GasInt
     bloom*:         BloomFilter
     logs*:          seq[Log]
 

--- a/eth_common/eth_types.nim
+++ b/eth_common/eth_types.nim
@@ -93,7 +93,7 @@ type
       status*: bool
 
   Receipt* = object
-    stateRootOrStatus*{.rlpCustomSerialization.}: HashOrStatus
+    stateRootOrStatus*: HashOrStatus
     cumulativeGasUsed*: GasInt
     bloom*:         BloomFilter
     logs*:          seq[Log]
@@ -254,17 +254,17 @@ proc append*(rlpWriter: var RlpWriter, t: Transaction, a: EthAddress) {.inline.}
   else:
     rlpWriter.append(a)
 
-proc read*(rlp: var Rlp, t: var Receipt, _: type HashOrStatus): HashOrStatus {.inline.} =
+proc read*(rlp: var Rlp, T: typedesc[HashOrStatus]): T {.inline.} =
   if rlp.blobLen == 1:
     result = hashOrStatus(rlp.read(uint8) == 1)
   else:
     result = hashOrStatus(rlp.read(Hash256))
 
-proc append*(rlpWriter: var RlpWriter, t: Receipt, a: HashOrStatus) {.inline.} =
-  if a.isHash:
-    rlpWriter.append(a.hash)
+proc append*(rlpWriter: var RlpWriter, value: HashOrStatus) {.inline.} =
+  if value.isHash:
+    rlpWriter.append(value.hash)
   else:
-    rlpWriter.append(if a.status: 1'u8 else: 0'u8)
+    rlpWriter.append(if value.status: 1'u8 else: 0'u8)
 
 proc read*(rlp: var Rlp, T: typedesc[Time]): T {.inline.} =
   result = fromUnix(rlp.read(int64))

--- a/eth_common/eth_types.nim
+++ b/eth_common/eth_types.nim
@@ -204,6 +204,20 @@ proc hashOrStatus*(hash: Hash256): HashOrStatus =
 proc hashOrStatus*(status: bool): HashOrStatus =
   HashOrStatus(isHash: false, status: status)
 
+proc hasStatus*(rec: Receipt): bool {.inline.} =
+  rec.stateRootOrStatus.isHash == false
+
+proc hasStateRoot*(rec: Receipt): bool {.inline.} =
+  rec.stateRootOrStatus.isHash == true
+
+proc stateRoot*(rec: Receipt): Hash256 {.inline.} =
+  assert(rec.hasStateRoot)
+  rec.stateRootOrStatus.hash
+
+proc status*(rec: Receipt): int {.inline.} =
+  assert(rec.hasStatus)
+  if rec.stateRootOrStatus.status: 1 else: 0
+
 #
 # Rlp serialization:
 #
@@ -255,6 +269,7 @@ proc append*(rlpWriter: var RlpWriter, t: Transaction, a: EthAddress) {.inline.}
     rlpWriter.append(a)
 
 proc read*(rlp: var Rlp, T: typedesc[HashOrStatus]): T {.inline.} =
+  assert(rlp.blobLen() == 32 or rlp.blobLen() == 1)
   if rlp.blobLen == 1:
     result = hashOrStatus(rlp.read(uint8) == 1)
   else:

--- a/tests/test.nim
+++ b/tests/test.nim
@@ -1,0 +1,31 @@
+import unittest, ../eth_common, rlp
+
+proc `==`(a, b: HashOrStatus): bool =
+  result = a.isHash == b.isHash
+  if not result: return
+  if a.isHash:
+    result = result and a.hash == b.hash
+  else:
+    result = result and a.status == b.status
+
+suite "rlp encoding":
+
+  test "receipt roundtrip":
+    var a, b, c, d: Receipt
+
+    var hash = rlpHash(a)
+    a.stateRootOrStatus = hashOrStatus(hash)
+    a.cumulativeGasUsed = 21000
+    a.logs = @[]
+
+    b.stateRootOrStatus = hashOrStatus(true)
+    b.cumulativeGasUsed = 52000
+    b.logs = @[]
+
+    var x = rlp.encode(a)
+    var y = rlp.encode(b)
+
+    c = x.decode(Receipt)
+    d = y.decode(Receipt)
+    check c == a
+    check d == b

--- a/tests/test.nim
+++ b/tests/test.nim
@@ -29,3 +29,8 @@ suite "rlp encoding":
     d = y.decode(Receipt)
     check c == a
     check d == b
+
+    check c.hasStateRoot
+    check c.stateRoot == hash
+    check d.hasStatus
+    check d.status == 1


### PR DESCRIPTION
what has been modified?
1. `gasUsed` become `cumulativeGasUsed`.
   reason: __gasUsed__ is misleading. It already been a trap hole for me, and will do for others too.
2. `stateRoot: Blob` become `stateRootOrStatus: HashOrStatus`.
   reason: after Byzantium fork and [EIP-658](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-658.md), stateRoot field can also represent transaction status
3. `topics: seq[int32]` become `topics: seq[Topic]` and `Topic` itself is `array[32, byte]`
   reason: it's simply not an int32.  The yellow paper said like that. 
   Topic can be Hash256 or zero padded bytes array

reference from yellow paper:
> ## Pre-Byzantium
> The transaction receipt is a tuple of four items comprising the __post-transaction state__, Rσ, the __cumulative gas used__ in the block containing the transaction receipt as of immediately after the transaction has happened, Ru, the set of logs created through execution of the transaction, Rl and the Bloom filter composed from information in those logs, Rb:

> ## Post-Byzantium
> The transaction receipt, R, is a tuple of four items comprising: the __cumulative gas used__ in the block containing the transaction receipt as of immediately after the transaction has happened, Ru, the set of logs created through execution of the transaction, Rl and the Bloom filter composed from information in those logs, Rb and the __status code of the transaction, Rz__:

> ## Log Topic
>The sequence Rl is a series of log entries, (O0; O1; :::). A log entry, O, is a tuple of the logger’s address, Oa, apossibly empty series of __32-byte log topics__, Ot and some number of bytes of data, Od:

